### PR TITLE
[BUGFIX] unexpected hash value leads to exception

### DIFF
--- a/Classes/IconpackRegistry.php
+++ b/Classes/IconpackRegistry.php
@@ -96,7 +96,7 @@ final class IconpackRegistry
 
         // Self-healing cache when an iconpack has been installed/changed.
         if ($hasCachedRegister) {
-            $hashes = $this->getIconpackCache()->getCacheByIdentifier('hashes');
+            $hashes = $this->getIconpackCache()->getCacheByIdentifier('hashes') ?: [];
             if (
                 count(array_diff(array_keys($this->iconpackRegister), $hashes))
             ) {


### PR DESCRIPTION
During deploy to a 12LTS test system I encountered a race condition with cache entries, I got a 
```
array_diff(): Argument #2 must be of type array, null given

in /vendor/quellenform/t3x-iconpack/Classes/IconpackRegistry.php line 101
```
The [lines](https://github.com/quellenform/t3x-iconpack/blob/f25aefadb928d0e373278ac2edb289a448e03b29/Classes/IconpackRegistry.php#L99-L101) imply that the cache will always be an array, however it could be null. 